### PR TITLE
Typescript support.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,7 @@ export = baidu_translate_api;
 declare function baidu_translate_api(
   query: string,
   opts: baidu_translate_api.options
-): baidu_translate_api.returnObject;
+): Promise<baidu_translate_api.returnObject>;
 
 declare namespace baidu_translate_api {
   export interface options {
@@ -15,7 +15,7 @@ declare namespace baidu_translate_api {
     to: string;
   }
 
-  export interface transObject {
+  export interface transResult {
     dst: string;
     src: string;
   }
@@ -23,6 +23,6 @@ declare namespace baidu_translate_api {
   export interface returnObject {
     from: string;
     to: string;
-    trans_object: transObject;
+    trans_result: transResult;
   }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,28 @@
+// Type definitions for baidu-translate-api v0.2.1
+// Project:https://github.com/TimLuo465/baidu-translate-api
+// Definitions by: Yesterday17 <https://github.com/Yesterday17>
+
+export = baidu_translate_api;
+
+declare function baidu_translate_api(
+  query: string,
+  opts: baidu_translate_api.options
+): baidu_translate_api.returnObject;
+
+declare namespace baidu_translate_api {
+  export interface options {
+    from: string;
+    to: string;
+  }
+
+  export interface transObject {
+    dst: string;
+    src: string;
+  }
+
+  export interface returnObject {
+    from: string;
+    to: string;
+    trans_object: transObject;
+  }
+}


### PR DESCRIPTION
created `index.d.ts` .

And if using Typescript, I also recommend using `enum` like this:
```typescript
const enum Language {
  Auto = "auto",
  Chinese = "zh",
  English = "en",
  Cantonese = "yue",
  ClassicalChinese = "wyw",
  Japanese = "jp",
  Korean = "kor",
  French = "fra",
  Spanish = "spa",
  Thai = "th",
  Arabic = "ara",
  Russian = "ru",
  Portuguese = "pt",
  German = "de",
  Italian = "it",
  Greek = "el",
  Dutch = "nl",
  Polish = "pl",
  Bulgarian = "bul",
  Estonian = "est",
  Danish = "dan",
  Finnish = "fin",
  Czech = "cs",
  Romanian = "rom",
  Slovenia = "slo",
  Swedish = "swe",
  Hungarian = "hu",
  TraditionalChinese = "cht",
  Vietnamese = "vie"
}
```
But it can't be written in `index.d.ts`, so I chose to say here, though there might be no one to see...（逃